### PR TITLE
Fix bug Heatmap

### DIFF
--- a/ktplotspy/plot/plot_cpdb_heatmap.py
+++ b/ktplotspy/plot/plot_cpdb_heatmap.py
@@ -83,7 +83,7 @@ def plot_cpdb_heatmap(
     all_int.columns = intr_pairs
     all_count = all_int.melt(ignore_index=False).reset_index()
     if degs_analysis:
-        all_count['significant'] = all_count[all_count.value == 1]
+        all_count['significant'] = all_count.value == 1
     else:
         all_count['significant'] = all_count.value < alpha
     count1x = all_count[["index", "significant"]].groupby("index").agg({"significant": "sum"})

--- a/ktplotspy/plot/plot_cpdb_heatmap.py
+++ b/ktplotspy/plot/plot_cpdb_heatmap.py
@@ -85,7 +85,7 @@ def plot_cpdb_heatmap(
     if degs_analysis:
         all_count['significant'] = all_count[all_count.value == 1]
     else:
-        all_count['significant'] = all_count.value < 0.05
+        all_count['significant'] = all_count.value < alpha
     count1x = all_count[["index", "significant"]].groupby("index").agg({"significant": "sum"})
     tmp = pd.DataFrame([x.split("|") for x in count1x.index])
     count_final = pd.concat([tmp, count1x.reset_index(drop=True)], axis=1)

--- a/ktplotspy/plot/plot_cpdb_heatmap.py
+++ b/ktplotspy/plot/plot_cpdb_heatmap.py
@@ -79,16 +79,15 @@ def plot_cpdb_heatmap(
     all_intr = pvals.copy()
     labels = metadata[celltype_key]
     intr_pairs = all_intr.interacting_pair
-    all_int = all_intr.iloc[:, 12 : all_intr.shape[1]].T
+    all_int = all_intr.iloc[:, 11 : all_intr.shape[1]].T
     all_int.columns = intr_pairs
     all_count = all_int.melt(ignore_index=False).reset_index()
     if degs_analysis:
-        all_count_lim = all_count[all_count.value == 1]
+        all_count['significant'] = all_count[all_count.value == 1]
     else:
-        all_count_lim = all_count[all_count.value < alpha]
-    count1x = all_count[["index", "interacting_pair"]].groupby("index").agg({"interacting_pair": "count"})
+        all_count['significant'] = all_count.value < 0.05
+    count1x = all_count[["index", "significant"]].groupby("index").agg({"significant": "sum"})
     tmp = pd.DataFrame([x.split("|") for x in count1x.index])
-    count1x = all_count_lim[["index", "interacting_pair"]].groupby("index").agg({"interacting_pair": "count"})
     count_final = pd.concat([tmp, count1x.reset_index(drop=True)], axis=1)
     count_final.columns = ["SOURCE", "TARGET", "COUNT"]
     if any(count_final.COUNT > 0):

--- a/ktplotspy/plot/plot_cpdb_heatmap.py
+++ b/ktplotspy/plot/plot_cpdb_heatmap.py
@@ -83,11 +83,12 @@ def plot_cpdb_heatmap(
     all_int.columns = intr_pairs
     all_count = all_int.melt(ignore_index=False).reset_index()
     if degs_analysis:
-        all_count = all_count[all_count.value == 1]
+        all_count_lim = all_count[all_count.value == 1]
     else:
-        all_count = all_count[all_count.value < alpha]
+        all_count_lim = all_count[all_count.value < alpha]
     count1x = all_count[["index", "interacting_pair"]].groupby("index").agg({"interacting_pair": "count"})
     tmp = pd.DataFrame([x.split("|") for x in count1x.index])
+    count1x = all_count_lim[["index", "interacting_pair"]].groupby("index").agg({"interacting_pair": "count"})
     count_final = pd.concat([tmp, count1x.reset_index(drop=True)], axis=1)
     count_final.columns = ["SOURCE", "TARGET", "COUNT"]
     if any(count_final.COUNT > 0):


### PR DESCRIPTION
Hi, after read the R version plot_heatmap, I found a difference in python code. Should take pvals[11:] rather than pvals[12:](first cell-cell interaction in pvalues.csv would be dropped if take [12:]). And I made my code more readable. Could you run a test on this?