### PR TITLE
fix the output table

### DIFF
--- a/docs/notebooks/tutorial.ipynb
+++ b/docs/notebooks/tutorial.ipynb
@@ -177,19 +177,17 @@
    "id": "e68e8721",
    "metadata": {},
    "source": [
-    "The values for the `symmetrical=False` mode follow the direction of the L-R direction where it's always moleculeA:celltypeA -> moleculeB:celltypeB. For example,\n",
+    "The values for the `symmetrical=False` mode follow the direction of the L-R direction where it's always moleculeA:celltypeA -> moleculeB:celltypeB.\n",
     "\n",
-    "#### Example 1: X -> Y axis\n",
-    "    \n",
-    "A=**MNPc(DC)** B=**NK cell**\n",
-    "    \n",
-    "A -> B is ***22*** interactions\n",
-    " \n",
-    "#### Example 2: Y -> X axis\n",
-    "   \n",
-    "A=**MNPc(DC)** B=**NK cell**\n",
-    "    \n",
-    "A -> B is ***20*** interactions"
+    "Therefore, if you trace on the `x-axis` for `celltype A` [MNPa(mono)] to `celltype B` [CD8T cell] on the `y-axis`:\n",
+    "\n",
+    "A -> B is 18 interactions\n",
+    "\n",
+    "Whereas if you trace on the `y-axis` for `celltype A` [MNPa(mono)] to `celltype B` [CD8T cell] on the `x-axis`:\n",
+    "\n",
+    "A -> B is 9 interactions\n",
+    "\n",
+    "`symmetrical=True` mode will return 18+9 = 27"
    ]
   },
   {

--- a/docs/notebooks/tutorial.ipynb
+++ b/docs/notebooks/tutorial.ipynb
@@ -673,6 +673,26 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "61826566",
+   "metadata": {},
+   "source": [
+    "## Saving the plots\n",
+    "\n",
+    "For `plot_cpdb`, because it's written with `plotnine`, you need to save it as follows:\n",
+    "\n",
+    "```python\n",
+    "p = plot_cpdb(...)\n",
+    "p.save(...)\n",
+    "```\n",
+    "see also:\n",
+    "https://plotnine.readthedocs.io/en/stable/generated/plotnine.ggplot.html\n",
+    "\n",
+    "For other functions, you can use seaborn/matplotlib saving conventions e.g. `plt.savefig`"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "3e5bfcbb",
    "metadata": {},

--- a/ktplotspy/plot/plot_cpdb_heatmap.py
+++ b/ktplotspy/plot/plot_cpdb_heatmap.py
@@ -12,6 +12,7 @@ from ktplotspy.utils.support import diverging_palette
 def plot_cpdb_heatmap(
     adata: "AnnData",  # actually not needed
     pvals: pd.DataFrame,
+    celltype_key: str,
     degs_analysis: bool = False,
     log1p_transform: bool = False,
     alpha: float = 0.05,

--- a/ktplotspy/plot/plot_cpdb_heatmap.py
+++ b/ktplotspy/plot/plot_cpdb_heatmap.py
@@ -10,9 +10,8 @@ from ktplotspy.utils.support import diverging_palette
 
 
 def plot_cpdb_heatmap(
-    adata: "AnnData",
+    adata: "AnnData",  # actually not needed
     pvals: pd.DataFrame,
-    celltype_key: str,
     degs_analysis: bool = False,
     log1p_transform: bool = False,
     alpha: float = 0.05,
@@ -75,9 +74,7 @@ def plot_cpdb_heatmap(
     Union[sns.matrix.ClusterGrid, Dict]
         Either heatmap of cellphonedb interactions or dataframe containing the interaction network.
     """
-    metadata = adata.obs.copy()
     all_intr = pvals.copy()
-    labels = metadata[celltype_key]
     intr_pairs = all_intr.interacting_pair
     all_int = all_intr.iloc[:, 11 : all_intr.shape[1]].T
     all_int.columns = intr_pairs
@@ -101,11 +98,6 @@ def plot_cpdb_heatmap(
             count_matx.columns = count_mat.columns
             count_matx.index = count_mat.index
             count_mat = count_matx.copy()
-            all_sum = pd.DataFrame(count_mat.apply(sum, axis=0), columns=["total_interactions"])
-        else:
-            all_sum = pd.DataFrame(count_mat.apply(sum, axis=0), columns=["total_interactions"]) + pd.DataFrame(
-                count_mat.apply(sum, axis=1), columns=["total_interactions"]
-            )
     if log1p_transform:
         count_mat = np.log1p(count_mat)
     if cmap is None:
@@ -126,5 +118,12 @@ def plot_cpdb_heatmap(
             g.fig.suptitle(title)
         return g
     else:
+        if symmetrical:
+            all_sum = pd.DataFrame(count_mat.apply(sum, axis=0), columns=["total_interactions"])
+        else:
+            count_mat = count_mat.T  # so that the table output is the same layout as the plot
+            row_sums = pd.DataFrame(count_mat.apply(sum, axis=0), columns=["total_interactions_row"])
+            col_sums = pd.DataFrame(count_mat.apply(sum, axis=1), columns=["total_interactions_col"])
+            all_sum = pd.concat([row_sums, col_sums], axis=1)
         out = {"count_network": count_mat, "interaction_count": all_sum, "interaction_edges": count_final}
         return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ktplotspy"
-version = "0.1.9"
+version = "0.1.10"
 description = "Python library for plotting Cellphonedb results. Ported from ktplots R package."
 authors = ["Kelvin Tuong <26215587+zktuong@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
So now the output table in `return_tables=True` gives the same layout as per the plot, particularly for `symmetrical=False` situation. Also rearranged the construction of the `interaction_count` output to be consistent with the options.

Also updated readme to give an indication for how to save the figures.

closes #22 