### PR TITLE
fix: prevent duplicate indices in `complex_idx1` and `complex_idx2`

### DIFF
--- a/src/ktplotspy/plot/plot_cpdb_chord.py
+++ b/src/ktplotspy/plot/plot_cpdb_chord.py
@@ -156,7 +156,7 @@ def plot_cpdb_chord(
         _interactions_subset = interactions_subset.loc[complex_id].copy()
         _interactions_subset_simp = interactions_subset.loc[simple_id].copy()
         complex_idx1 = [i for i, j in _interactions_subset.partner_b.items() if re.search("complex:", j)]
-        complex_idx2 = [i for i, j in _interactions_subset.partner_a.items() if re.search("complex:", j)]
+        complex_idx2 = [i for i, j in _interactions_subset.partner_a.items() if re.search("complex:", j) and i not in complex_idx1]
         # complex_idx
         simple_1 = list(_interactions_subset.loc[complex_idx1, "interacting_pair"])
         simple_2 = list(_interactions_subset.loc[complex_idx2, "interacting_pair"])


### PR DESCRIPTION
# BUG description
While some interactions (e.g., CPI-CC0AFC21177, CPI-CC02E4FE92E) contain "complex:" in both `partner_b` and `partner_a`, original code inadvertently adds the same indices to `complex_idx1` and `complex_idx2`. This duplication causes extra rows in `tmpdf`, resulting in a mismatch between `tmpdf` and `complex_id` and eventually raising "ValueError: Length mismatch" in `tmpdf.index = complex_id`, line 170.

# Solution
Prevent adding indices to `complex_idx2` if it already exists in `complex_idx1`.