### PR TITLE
fix(plot_cpdb_chord): prevent potential content mismatch between `_interactions_subset` and `tmpdf`

### DIFF
--- a/src/ktplotspy/plot/plot_cpdb_chord.py
+++ b/src/ktplotspy/plot/plot_cpdb_chord.py
@@ -167,7 +167,8 @@ def plot_cpdb_chord(
         for i, _ in enumerate(simple_2):
             simple_2[i] = re.sub(partner_2[i] + "_|_" + partner_2[i], "", simple_2[i])
         tmpdf = pd.concat([pd.DataFrame(zip(simple_1, partner_1)), pd.DataFrame(zip(partner_2, simple_2))])
-        tmpdf.index = complex_id
+        tmpdf.index = complex_idx1 + complex_idx2
+        tmpdf = tmpdf.sort_index()
         tmpdf.columns = ["id_a", "id_b"]
         _interactions_subset = pd.concat([_interactions_subset, tmpdf], axis=1)
         simple_tm0 = pd.DataFrame(


### PR DESCRIPTION
# Problem description
When the ranges of `complex_idx1` and `complex_idx2` overlap, the indices of `tmpdf` can become misaligned with the concatenated `(simple_1, partner_1)` and `(partner_2, simple_2)` if we simply assign `complex_id` to `tmpdf.index`. This misalignment causes inconsistencies among `id_a`, `id_b`, and `interacting_pair`.
![mismatch](https://github.com/user-attachments/assets/883795d9-01ed-48c4-9d6a-043f531bfec0)

This seems to have an effect on the legend.

# Solution
Ensure the new indices of `tmpdf` match the concatenated dataframe, and `tmpdf` is properly aligned with `_interactions_subset`.