### PR TITLE
fix: use iteration variable instead of list in loop

### DIFF
--- a/src/ktplotspy/plot/plot_cpdb.py
+++ b/src/ktplotspy/plot/plot_cpdb.py
@@ -191,10 +191,11 @@ def plot_cpdb(
         # Copy the values from means_mat to new_df
         tmp_pvals_mat.iloc[:, :col_start] = means_mat.iloc[:, :col_start]
         tmp_pvals_mat.update(pvals_mat)
+        num_cols = tmp_pvals_mat.select_dtypes(include="number").columns
         if degs_analysis:
-            tmp_pvals_mat.fillna(0, inplace=True)
+            tmp_pvals_mat[num_cols] = tmp_pvals_mat[num_cols].fillna(0)
         else:
-            tmp_pvals_mat.fillna(1, inplace=True)
+            tmp_pvals_mat[num_cols] = tmp_pvals_mat[num_cols].fillna(1)
         pvals_mat = tmp_pvals_mat.copy()
 
     if (interaction_scores is not None) & (cellsign is not None):
@@ -390,7 +391,7 @@ def plot_cpdb(
             exclude_interactions = [exclude_interactions]
         df = df[~df.interaction_group.isin(exclude_interactions)]
 
-    df["neglog10p"] = abs(-1 * np.log10(df.pvals))
+    df["neglog10p"] = abs(-1 * np.log10(df.pvals.astype(float)))
     df["neglog10p"] = [0 if x >= 0.05 else j for x, j in zip(df["pvals"], df["neglog10p"])]
     df["significant"] = ["yes" if x < alpha else np.nan for x in df.pvals]
 

--- a/src/ktplotspy/plot/plot_cpdb_chord.py
+++ b/src/ktplotspy/plot/plot_cpdb_chord.py
@@ -292,7 +292,7 @@ def plot_cpdb_chord(
                         else:
                             intx = intx_
                     else:
-                        pass # intx is already assigned
+                        pass  # intx is already assigned
                     tmpint.append(intx)
             if len(tmpint) > 0:
                 tmpdf = tmpdf[tmpdf.converted_pair.isin(tmpint)]

--- a/src/ktplotspy/plot/plot_cpdb_chord.py
+++ b/src/ktplotspy/plot/plot_cpdb_chord.py
@@ -280,22 +280,22 @@ def plot_cpdb_chord(
         elif isinstance(interaction, list):
             tmpint = []
             for intx in interaction:
-                if "-" in interaction:
+                if "-" in intx:
                     # first check if the interaction is exactly in the converted_pair
-                    int_check = interaction in list(tmpdf.converted_pair.unique())
+                    int_check = intx in list(tmpdf.converted_pair.unique())
                     if not int_check:
                         # flip the so that the first becomes last
-                        interaction_ = "-".join(interaction.split("-")[::-1])
-                        int_check = interaction_ in list(tmpdf.converted_pair.unique())
+                        intx_ = "-".join(intx.split("-")[::-1])
+                        int_check = intx_ in list(tmpdf.converted_pair.unique())
                         if not int_check:
-                            raise ValueError(f"Neither {interaction} nor {interaction_} are found in the data.")
+                            raise ValueError(f"Neither {intx} nor {intx_} are found in the data.")
                         else:
-                            intx = interaction_
+                            intx = intx_
                     else:
-                        intx = interaction
+                        pass # intx is already assigned
                     tmpint.append(intx)
             if len(tmpint) > 0:
-                tmpdf = tmpdf[tmpdf.converted_pair.isin([tmpint])]
+                tmpdf = tmpdf[tmpdf.converted_pair.isin(tmpint)]
             else:
                 tmpdf = tmpdf[tmpdf.converted_pair.str.contains("|".join(lr_intx))]
     if link_colors is None:


### PR DESCRIPTION
## Problem Description

Fixed a bug in the `plot_cpdb_chord` function when processing the `interaction` parameter. In the `for intx in interaction:` loop, the code incorrectly used `interaction` (the entire list) instead of `intx` (the current iteration element). When a list containing interaction pairs (e.g., `['CXCL8-ACKR1']`) was passed, the code incorrectly accessed the entire list object instead of individual elements within the list, causing interaction pairs to be incorrectly parsed.

## Bug Impact

When users specify a list of specific interaction pairs, the function unexpectedly plots all interactions containing those genes, rather than only the specified interaction pairs.

**Example:**
- **Input:** `interaction=['CXCL8-ACKR1']`
- **Expected behavior:** Only plot the `CXCL8-ACKR1` interaction pair
- **Actual behavior:** Plots `CXCL8-ACKR1`, `CXCL1-ACKR1`, `CCL5-ACKR1`, and all other interactions containing `CXCL8` or `ACKR1`